### PR TITLE
Remove need for BUILD_DIR & install headers

### DIFF
--- a/EtcLib/EtcLib.pro
+++ b/EtcLib/EtcLib.pro
@@ -1,9 +1,4 @@
-#-------------------------------------------------
-#
-# Project created by QtCreator 2016-10-24T11:51:10
-#
-#-------------------------------------------------
-
+include(../common.pri)
 QT       -= gui
 
 TARGET = EtcLib
@@ -12,8 +7,7 @@ CONFIG += c++11
 
 DEFINES += ETCLIB_LIBRARY
 
-isEmpty(BUILD_DIR) : BUILD_DIR = $$(BUILD_DIR)
-DESTDIR = $$BUILD_DIR
+DESTDIR = $$ETC2_LIBRARY_DESTINATION
 
 INCLUDEPATH += EtcCodec/ \
                Etc/
@@ -55,3 +49,11 @@ HEADERS +=\
     EtcCodec/EtcErrorMetric.h \
     EtcCodec/EtcIndividualTrys.h \
     EtcCodec/EtcSortedBlockList.h
+
+header_files.path = $$ETC2_BUILD_ROOT/include
+for(header, HEADERS) {
+  eval(header_files.files += $$header)
+}
+
+INSTALLS += header_files
+

--- a/EtcTool/EtcTool.pro
+++ b/EtcTool/EtcTool.pro
@@ -1,9 +1,4 @@
-#-------------------------------------------------
-#
-# Project created by QtCreator 2016-10-24T13:36:59
-#
-#-------------------------------------------------
-
+include(../common.pri)
 QT       -= gui
 
 TARGET = EtcTool
@@ -12,11 +7,9 @@ CONFIG += c++11
 
 DEFINES += ETCTOOL_LIBRARY
 
-LIBS += -L$$BUILD_DIR
-LIBS += -lEtcLib
+DESTDIR = $$ETC2_LIBRARY_DESTINATION
 
-isEmpty(BUILD_DIR) : BUILD_DIR = $$(BUILD_DIR)
-DESTDIR = $$BUILD_DIR
+LIBS += -lEtcLib
 
 INCLUDEPATH += ../EtcLib/EtcCodec/ \
                ../EtcLib/Etc/ \
@@ -33,7 +26,7 @@ SOURCES += \
     ../third_party/lodepng/lodepng.cpp
 
 HEADERS +=\
-        etctool_global.h \
+    etctool_global.h \
     EtcAnalysis.h \
     EtcComparison.h \
     EtcFile.h \
@@ -42,3 +35,10 @@ HEADERS +=\
     EtcSourceImage.h \
     EtcTool.h \
     ../third_party/lodepng/lodepng.h
+
+header_files.path = $$ETC2_BUILD_ROOT/include
+for(header, HEADERS) {
+  eval(header_files.files += $$header)
+}
+
+INSTALLS += header_files

--- a/common.pri
+++ b/common.pri
@@ -1,0 +1,29 @@
+CONFIG(debug, debug|release) {
+  BUILD_TYPE = debug
+} else {
+  BUILD_TYPE = release
+}
+
+# Make sure that the BUILD_ROOT environment variable is set. Without it we don't know where to build.
+isEmpty(ETC2_BUILD_ROOT) : ETC2_BUILD_ROOT = $$(ETC2_BUILD_ROOT)
+isEmpty(ETC2_BUILD_ROOT) {
+  greaterThan(QT_MAJOR_VERSION, 4) {
+    # Qt 5 introduced a special 'shadowed' replace function that gives us access to the build directory.
+    ETC2_BUILD_ROOT = $$shadowed(.)
+  }
+  else {
+    ETC2_BUILD_ROOT = $$PWD/objects/$$BUILD_TYPE
+  }
+}
+
+isEmpty(ETC2_LIBRARY_DESTINATION) : ETC2_LIBRARY_DESTINATION = $$(ETC2_LIBRARY_DESTINATION)
+isEmpty(ETC2_LIBRARY_DESTINATION) {
+  dest = $$ETC2_BUILD_ROOT/lib
+  ETC2_LIBRARY_DESTINATION = $$replace(dest, /, $$QMAKE_DIR_SEP)
+}
+
+LIBS += -L$$ETC2_LIBRARY_DESTINATION
+
+macx {
+  QMAKE_LFLAGS = -Wl,-install_name,$$ETC2_LIBRARY_DESTINATION/$(TARGET)
+}


### PR DESCRIPTION
* No need to specify `BUILD_DIR` anymore.
* Libraries are now in `lib` folder, headers in `include` folder.
* All header files are copied into include via `make install`.
* hardcode library runtime search path on OSX (same as e.g. OpenEXR).
